### PR TITLE
Use 5.7.* of illuminate/support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "illuminate/console": "5.7.*",
         "laravel/passport": "^7.0",
-        "illuminate/support": "^5.7"
+        "illuminate/support": "5.7.*"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.5"


### PR DESCRIPTION
Laravel doesn't follow semver, and breaking changes might be introduced in 5.8 of the "support" component (which `^5.7` would allow for). 